### PR TITLE
FIX: Standard definition for `mkEnableOption`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ And in HTML with proper styling.
 
 ### Prerequisites
 
-- Rust 1.70 or later
+- Rust 1.85 or later
 - Git (for repository cloning features)
 
 ### Building and Testing

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -180,7 +180,7 @@ fn parse_attrset(
 
                     options.push(OptionDoc {
                         name: current_prefix.to_string(),
-                        description,
+                        description: Some(format!("Wether to enable {}.", description.unwrap_or(String::new()))),
                         nix_type: "boolean".to_string(),
                         default_value: Some(String::from("false")),
                         example: Some(String::from("true")),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -180,7 +180,10 @@ fn parse_attrset(
 
                     options.push(OptionDoc {
                         name: current_prefix.to_string(),
-                        description: Some(format!("Wether to enable {}.", description.unwrap_or(String::new()))),
+                        description: Some(format!(
+                            "Wether to enable {}.",
+                            description.unwrap_or(String::new())
+                        )),
                         nix_type: "boolean".to_string(),
                         default_value: Some(String::from("false")),
                         example: Some(String::from("true")),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -181,7 +181,7 @@ fn parse_attrset(
                     options.push(OptionDoc {
                         name: current_prefix.to_string(),
                         description: Some(format!(
-                            "Wether to enable {}.",
+                            "Whether to enable {}.",
                             description.unwrap_or(String::new())
                         )),
                         nix_type: "boolean".to_string(),

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -38,7 +38,7 @@ fn test_basic_option_parsing() -> Result<(), Box<dyn std::error::Error + Send + 
     assert_eq!(options[0].nix_type.to_string(), "boolean");
     assert_eq!(
         options[0].description,
-        Some("Simple test option".to_string())
+        Some("Wether to enable Simple test option.".to_string())
     );
     assert_eq!(options[0].default_value, Some("false".to_string()));
 

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -38,7 +38,7 @@ fn test_basic_option_parsing() -> Result<(), Box<dyn std::error::Error + Send + 
     assert_eq!(options[0].nix_type.to_string(), "boolean");
     assert_eq!(
         options[0].description,
-        Some("Wether to enable Simple test option.".to_string())
+        Some("Whether to enable Simple test option.".to_string())
     );
     assert_eq!(options[0].default_value, Some("false".to_string()));
 


### PR DESCRIPTION
This PR adds:

- Support for standard behavior on the `mkEnableOption` key (raised in #6)
- Updated test to match the new feature
- Updated README with minimal Cargo version not compatible with current dependencies tree.

All my changes pass build, fmt, clippy, test and run.