### PR TITLE
Set NIX_CFLAGS_COMPILE to use GNU17 standard

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             version = manifest.version;
             src = pkgs.lib.cleanSource ./.;
             cargoLock.lockFile = ./Cargo.lock;
+            env.NIX_CFLAGS_COMPILE = "-std=gnu17";
           };
       }
     );


### PR DESCRIPTION
Fixes a compile error with the oniguruma dependency:

<details><summary>Details</summary>
<p>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/6wg6kdrwgcbz9pk7783icbpp8z4h66x5-source
source root is source
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Executing cargoSetupPostPatchHook
Validating consistency between /build/source/Cargo.lock and /build/cargo-vendor-dir/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing cargoBuildHook
cargoBuildHook flags: -j 16 --target x86_64-unknown-linux-gnu --offline --profile release
[1m[92m   Compiling[0m proc-macro2 v1.0.94
[1m[92m   Compiling[0m unicode-ident v1.0.18
[1m[92m   Compiling[0m libc v0.2.171
[1m[92m   Compiling[0m memchr v2.7.4
[1m[92m   Compiling[0m cfg-if v1.0.0
[1m[92m   Compiling[0m once_cell v1.21.1
[1m[92m   Compiling[0m regex-syntax v0.8.5
[1m[92m   Compiling[0m autocfg v1.4.0
[1m[92m   Compiling[0m thiserror v2.0.12
[1m[92m   Compiling[0m serde v1.0.219
[1m[92m   Compiling[0m smallvec v1.14.0
[1m[92m   Compiling[0m bytes v1.10.1
[1m[92m   Compiling[0m tinyvec_macros v0.1.1
[1m[92m   Compiling[0m crossbeam-utils v0.8.21
[1m[92m   Compiling[0m parking_lot_core v0.9.10
[1m[92m   Compiling[0m gix-trace v0.1.12
[1m[92m   Compiling[0m scopeguard v1.2.0
[1m[92m   Compiling[0m tinyvec v1.9.0
[1m[92m   Compiling[0m fastrand v2.3.0
[1m[92m   Compiling[0m log v0.4.26
[1m[92m   Compiling[0m itoa v1.0.15
[1m[92m   Compiling[0m adler2 v2.0.0
[1m[92m   Compiling[0m bitflags v2.9.0
[1m[92m   Compiling[0m crc32fast v1.4.2
[1m[92m   Compiling[0m miniz_oxide v0.8.5
[1m[92m   Compiling[0m same-file v1.0.6
[1m[92m   Compiling[0m human_format v1.1.0
[1m[92m   Compiling[0m bytesize v1.3.2
[1m[92m   Compiling[0m sha1_smol v1.0.1
[1m[92m   Compiling[0m version_check v0.9.5
[1m[92m   Compiling[0m lock_api v0.4.12
[1m[92m   Compiling[0m walkdir v2.5.0
[1m[92m   Compiling[0m home v0.5.11
[1m[92m   Compiling[0m zerocopy v0.7.35
[1m[92m   Compiling[0m allocator-api2 v0.2.21
[1m[92m   Compiling[0m jiff v0.1.29
[1m[92m   Compiling[0m rustix v1.0.2
[1m[92m   Compiling[0m aho-corasick v1.1.3
[1m[92m   Compiling[0m ahash v0.8.11
[1m[92m   Compiling[0m quote v1.0.40
[1m[92m   Compiling[0m flate2 v1.1.0
[1m[92m   Compiling[0m crossbeam-channel v0.5.14
[1m[92m   Compiling[0m winnow v0.6.26
[1m[92m   Compiling[0m linux-raw-sys v0.9.3
[1m[92m   Compiling[0m getrandom v0.3.1
[1m[92m   Compiling[0m memmap2 v0.9.5
[1m[92m   Compiling[0m syn v2.0.100
[1m[92m   Compiling[0m unicode-normalization v0.1.24
[1m[92m   Compiling[0m fnv v1.0.7
[1m[92m   Compiling[0m shlex v1.3.0
[1m[92m   Compiling[0m stable_deref_trait v1.2.0
[1m[92m   Compiling[0m hashbrown v0.14.5
[1m[92m   Compiling[0m signal-hook v0.3.17
[1m[92m   Compiling[0m parking_lot v0.12.3
[1m[92m   Compiling[0m cc v1.2.16
[1m[92m   Compiling[0m signal-hook-registry v1.4.2
[1m[92m   Compiling[0m writeable v0.5.5
[1m[92m   Compiling[0m prodash v29.0.1
[1m[92m   Compiling[0m litemap v0.7.5
[1m[92m   Compiling[0m pin-project-lite v0.2.16
[1m[92m   Compiling[0m futures-core v0.3.31
[1m[92m   Compiling[0m unicode-bom v2.0.3
[1m[92m   Compiling[0m rustix v0.38.44
[1m[92m   Compiling[0m icu_locid_transform_data v1.5.0
[1m[92m   Compiling[0m static_assertions v1.1.0
[1m[92m   Compiling[0m foldhash v0.1.5
[1m[92m   Compiling[0m shell-words v1.1.0
[1m[92m   Compiling[0m kstring v2.0.2
[1m[92m   Compiling[0m socket2 v0.5.8
[1m[92m   Compiling[0m hashbrown v0.15.2
[1m[92m   Compiling[0m mio v1.0.3
[1m[92m   Compiling[0m slab v0.4.9
[1m[92m   Compiling[0m dashmap v6.1.0
[1m[92m   Compiling[0m futures-sink v0.3.31
[1m[92m   Compiling[0m icu_properties_data v1.5.0
[1m[92m   Compiling[0m linux-raw-sys v0.4.15
[1m[92m   Compiling[0m utf16_iter v1.0.5
[1m[92m   Compiling[0m icu_normalizer_data v1.5.0
[1m[92m   Compiling[0m utf8_iter v1.0.4
[1m[92m   Compiling[0m write16 v1.0.0
[1m[92m   Compiling[0m http v1.3.1
[1m[92m   Compiling[0m tokio v1.44.1
[1m[92m   Compiling[0m regex-automata v0.4.9
[1m[92m   Compiling[0m encoding_rs v0.8.35
[1m[92m   Compiling[0m percent-encoding v2.3.1
[1m[92m   Compiling[0m rustls-pki-types v1.11.0
[1m[92m   Compiling[0m form_urlencoded v1.2.1
[1m[92m   Compiling[0m gix-sec v0.10.11
[1m[92m   Compiling[0m getrandom v0.2.15
[1m[92m   Compiling[0m tracing-core v0.1.33
[1m[92m   Compiling[0m ring v0.17.14
[1m[92m   Compiling[0m futures-io v0.3.31
[1m[92m   Compiling[0m equivalent v1.0.2
[1m[92m   Compiling[0m untrusted v0.9.0
[1m[92m   Compiling[0m httparse v1.10.1
[1m[92m   Compiling[0m ryu v1.0.20
[1m[92m   Compiling[0m futures-task v0.3.31
[1m[92m   Compiling[0m pin-utils v0.1.0
[1m[92m   Compiling[0m http-body v1.0.1
[1m[92m   Compiling[0m tracing v0.1.41
[1m[92m   Compiling[0m futures-util v0.3.31
[1m[92m   Compiling[0m indexmap v2.8.0
[1m[92m   Compiling[0m try-lock v0.2.5
[1m[92m   Compiling[0m atomic-waker v1.1.2
[1m[92m   Compiling[0m rustls v0.23.23
[1m[92m   Compiling[0m want v0.3.1
[1m[92m   Compiling[0m futures-channel v0.3.31
[1m[92m   Compiling[0m filetime v0.2.25
[1m[92m   Compiling[0m tempfile v3.19.0
[1m[92m   Compiling[0m tower-service v0.3.3
[1m[92m   Compiling[0m zeroize v1.8.1
[1m[92m   Compiling[0m subtle v2.6.1
[1m[92m   Compiling[0m strsim v0.11.1
[1m[92m   Compiling[0m pkg-config v0.3.32
[1m[92m   Compiling[0m ident_case v1.0.1
[1m[92m   Compiling[0m utf8parse v0.2.2
[1m[92m   Compiling[0m webpki-roots v0.26.8
[1m[92m   Compiling[0m anstyle-parse v0.2.6
[1m[92m   Compiling[0m sync_wrapper v1.0.2
[1m[92m   Compiling[0m anstyle-query v1.1.2
[1m[92m   Compiling[0m anstyle v1.0.10
[1m[92m   Compiling[0m colorchoice v1.0.3
[1m[92m   Compiling[0m is_terminal_polyfill v1.70.1
[1m[92m   Compiling[0m rustversion v1.0.20
[1m[92m   Compiling[0m tower-layer v0.3.3
[1m[92m   Compiling[0m prettyplease v0.2.31
[1m[92m   Compiling[0m http-body-util v0.1.3
[1m[92m   Compiling[0m anstream v0.6.18
[1m[92m   Compiling[0m rustls-pemfile v2.2.0
[1m[92m   Compiling[0m onig_sys v69.8.1
[1m[92m   Compiling[0m base64 v0.22.1
[1m[92m   Compiling[0m serde_json v1.0.140
[1m[92m   Compiling[0m thiserror v1.0.69
[1m[92m   Compiling[0m ipnet v2.11.0
[1m[92m   Compiling[0m mime v0.3.17
[1m[92m   Compiling[0m arrayvec v0.7.6
[1m[92m   Compiling[0m terminal_size v0.4.2
[1m[92m   Compiling[0m uluru v3.1.0
[1m[92m   Compiling[0m imara-diff v0.1.8
[1m[92m   Compiling[0m crossbeam-epoch v0.9.18
[1m[92m   Compiling[0m bitflags v1.3.2
[1m[92m   Compiling[0m heck v0.5.0
[1m[92m   Compiling[0m synstructure v0.13.1
[1m[92m   Compiling[0m darling_core v0.20.10
[1m[92m   Compiling[0m clru v0.6.2
[1m[92m   Compiling[0m unicode-width v0.2.0
[1m[92m   Compiling[0m rayon-core v1.12.1
[1m[92m   Compiling[0m clap_lex v0.7.4
[1m[92m   Compiling[0m portable-atomic v1.11.0
[1m[92m   Compiling[0m crossbeam-deque v0.8.6
[1m[92m   Compiling[0m bstr v1.11.3
[1m[92m   Compiling[0m regex v1.11.1
[1m[92m   Compiling[0m clap_builder v4.5.32
[1m[92m   Compiling[0m io-close v0.3.7
[1m[92m   Compiling[0m text-size v1.1.1
[1m[92m   Compiling[0m arc-swap v1.7.1
[1m[92m   Compiling[0m rustc-hash v1.1.0
[1m[92m   Compiling[0m countme v3.0.1
[1m[92m   Compiling[0m deunicode v1.6.1
[1m[92m   Compiling[0m rowan v0.15.16
[1m[92m   Compiling[0m env_filter v0.1.3
[1m[92m   Compiling[0m gix-utils v0.1.14
[1m[92m   Compiling[0m tokio-util v0.7.14
[1m[92m   Compiling[0m tower v0.5.2
[1m[92m   Compiling[0m slug v0.1.6
[1m[92m   Compiling[0m console v0.15.11
[1m[92m   Compiling[0m caseless v0.2.2
[1m[92m   Compiling[0m csv-core v0.1.12
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'onig_st_init_strend_table_with_size':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:588:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_str_end_key *, st_str_end_key *)' [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   588 |     str_end_cmp,
[1m[33mwarning[0m: onig_sys@69.8.1:       |     ^~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:588:5: note: (near initialization for 'hashType.compare')
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:550:1: note: 'str_end_cmp' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   550 | str_end_cmp(st_str_end_key* x, st_str_end_key* y)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:589:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_str_end_key *)' [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   589 |     str_end_hash,
[1m[33mwarning[0m: onig_sys@69.8.1:       |     ^~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:589:5: note: (near initialization for 'hashType.hash')
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:571:1: note: 'str_end_hash' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   571 | str_end_hash(st_str_end_key* x)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'onig_st_init_callout_name_table_with_size':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:678:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_callout_name_key *, st_callout_name_key *)' [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   678 |     callout_name_table_cmp,
[1m[33mwarning[0m: onig_sys@69.8.1:       |     ^~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:678:5: note: (near initialization for 'hashType.compare')
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:637:1: note: 'callout_name_table_cmp' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   637 | callout_name_table_cmp(st_callout_name_key* x, st_callout_name_key* y)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:679:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_callout_name_key *)' [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   679 |     callout_name_table_hash,
[1m[33mwarning[0m: onig_sys@69.8.1:       |     ^~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:679:5: note: (near initialization for 'hashType.hash')
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:660:1: note: 'callout_name_table_hash' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   660 | callout_name_table_hash(st_callout_name_key* x)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'names_clear':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:804:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   804 |     onig_st_foreach(t, i_free_name_entry, 0);
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        |
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, NameEntry *, void *) {aka int (*)(unsigned char *, NameEntry *, void *)}
[1m[33mwarning[0m: onig_sys@69.8.1: In file included from oniguruma/src/regparse.c:37:
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, NameEntry *, void *)' {aka 'int (*)(unsigned char *, NameEntry *, void *)'}
[1m[33mwarning[0m: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
[1m[33mwarning[0m: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro '_'
[1m[33mwarning[0m: onig_sys@69.8.1:    35 | # define _(args) args
[1m[33mwarning[0m: onig_sys@69.8.1:       |                  ^~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:789:1: note: 'i_free_name_entry' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   789 | i_free_name_entry(UChar* key, NameEntry* e, void* arg ARG_UNUSED)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'onig_foreach_name':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:873:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   873 |     onig_st_foreach(t, i_names, (HashDataType )&narg);
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        ^~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        |
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, NameEntry *, INamesArg *) {aka int (*)(unsigned char *, NameEntry *, INamesArg *)}
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, NameEntry *, INamesArg *)' {aka 'int (*)(unsigned char *, NameEntry *, INamesArg *)'}
[1m[33mwarning[0m: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
[1m[33mwarning[0m: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro '_'
[1m[33mwarning[0m: onig_sys@69.8.1:    35 | # define _(args) args
[1m[33mwarning[0m: onig_sys@69.8.1:       |                  ^~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:846:1: note: 'i_names' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   846 | i_names(UChar* key ARG_UNUSED, NameEntry* e, INamesArg* arg)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'onig_renumber_name_table':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:901:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:   901 |     onig_st_foreach(t, i_renumber_name, (HashDataType )map);
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        |
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, NameEntry *, GroupNumMap *) {aka int (*)(unsigned char *, NameEntry *, GroupNumMap *)}
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, NameEntry *, GroupNumMap *)' {aka 'int (*)(unsigned char *, NameEntry *, GroupNumMap *)'}
[1m[33mwarning[0m: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
[1m[33mwarning[0m: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro '_'
[1m[33mwarning[0m: onig_sys@69.8.1:    35 | # define _(args) args
[1m[33mwarning[0m: onig_sys@69.8.1:       |                  ^~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:879:1: note: 'i_renumber_name' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:   879 | i_renumber_name(UChar* key ARG_UNUSED, NameEntry* e, GroupNumMap* map)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'callout_name_table_clear':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:1386:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:  1386 |     onig_st_foreach(t, i_free_callout_name_entry, 0);
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        |
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        int (*)(st_callout_name_key *, CalloutNameEntry *, void *)
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(st_callout_name_key *, CalloutNameEntry *, void *)'
[1m[33mwarning[0m: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
[1m[33mwarning[0m: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro '_'
[1m[33mwarning[0m: onig_sys@69.8.1:    35 | # define _(args) args
[1m[33mwarning[0m: onig_sys@69.8.1:       |                  ^~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:1370:1: note: 'i_free_callout_name_entry' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:  1370 | i_free_callout_name_entry(st_callout_name_key* key, CalloutNameEntry* e,
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'setup_ext_callout_list_values':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:1884:56: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:  1884 |     onig_st_foreach((CalloutTagTable *)ext->tag_table, i_callout_callout_list_set,
[1m[33mwarning[0m: onig_sys@69.8.1:       |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1:       |                                                        |
[1m[33mwarning[0m: onig_sys@69.8.1:       |                                                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, CalloutTagVal,  void *)' {aka 'int (*)(unsigned char *, long int,  void *)'}
[1m[33mwarning[0m: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
[1m[33mwarning[0m: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro '_'
[1m[33mwarning[0m: onig_sys@69.8.1:    35 | # define _(args) args
[1m[33mwarning[0m: onig_sys@69.8.1:       |                  ^~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:1866:1: note: 'i_callout_callout_list_set' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:  1866 | i_callout_callout_list_set(UChar* key, CalloutTagVal e, void* arg)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c: In function 'callout_tag_table_clear':
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:1932:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
[1m[33mwarning[0m: onig_sys@69.8.1:  1932 |     onig_st_foreach(t, i_free_callout_tag_entry, 0);
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        ^~~~~~~~~~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        |
[1m[33mwarning[0m: onig_sys@69.8.1:       |                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, CalloutTagVal,  void *)' {aka 'int (*)(unsigned char *, long int,  void *)'}
[1m[33mwarning[0m: onig_sys@69.8.1:    55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
[1m[33mwarning[0m: onig_sys@69.8.1:       |                               ^~~~~~~~~~~~~~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/st.h:35:18: note: in definition of macro '_'
[1m[33mwarning[0m: onig_sys@69.8.1:    35 | # define _(args) args
[1m[33mwarning[0m: onig_sys@69.8.1:       |                  ^~~~
[1m[33mwarning[0m: onig_sys@69.8.1: oniguruma/src/regparse.c:1922:1: note: 'i_free_callout_tag_entry' declared here
[1m[33mwarning[0m: onig_sys@69.8.1:  1922 | i_free_callout_tag_entry(UChar* key, CalloutTagVal e, void* arg ARG_UNUSED)
[1m[33mwarning[0m: onig_sys@69.8.1:       | ^~~~~~~~~~~~~~~~~~~~~~~~
[1m[91merror[0m: failed to run custom build command for `onig_sys v69.8.1`

Caused by:
  process didn't exit successfully: `/build/source/target/release/build/onig_sys-f48faa2e99750b81/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=RUSTONIG_DYNAMIC_LIBONIG
  cargo:rerun-if-env-changed=RUSTONIG_STATIC_LIBONIG
  cargo:rerun-if-env-changed=RUSTONIG_SYSTEM_LIBONIG
  OUT_DIR = Some(/build/source/target/x86_64-unknown-linux-gnu/release/build/onig_sys-34fd91aa366dab34/out)
  OPT_LEVEL = Some(3)
  TARGET = Some(x86_64-unknown-linux-gnu)
  HOST = Some(x86_64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
  CC_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
  CC_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = Some(/nix/store/kbw2j1vag664b3sj3rjwz9v53cqx87sb-gcc-wrapper-15.2.0/bin/cc)
  RUSTC_WRAPPER = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(false)
  CARGO_CFG_TARGET_FEATURE = Some(fxsr,sse,sse2)
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  CARGO_ENCODED_RUSTFLAGS = Some(-Cforce-frame-pointers=yes)
  OUT_DIR = Some(/build/source/target/x86_64-unknown-linux-gnu/release/build/onig_sys-34fd91aa366dab34/out)
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  TARGET = Some(x86_64-unknown-linux-gnu)
  CARGO_CFG_TARGET_FEATURE = Some(fxsr,sse,sse2)
  HOST = Some(x86_64-unknown-linux-gnu)
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  cargo:warning=oniguruma/src/regparse.c: In function 'onig_st_init_strend_table_with_size':
  cargo:warning=oniguruma/src/regparse.c:588:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_str_end_key *, st_str_end_key *)' [-Wincompatible-pointer-types]
  cargo:warning=  588 |     str_end_cmp,
  cargo:warning=      |     ^~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:588:5: note: (near initialization for 'hashType.compare')
  cargo:warning=oniguruma/src/regparse.c:550:1: note: 'str_end_cmp' declared here
  cargo:warning=  550 | str_end_cmp(st_str_end_key* x, st_str_end_key* y)
  cargo:warning=      | ^~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:589:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_str_end_key *)' [-Wincompatible-pointer-types]
  cargo:warning=  589 |     str_end_hash,
  cargo:warning=      |     ^~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:589:5: note: (near initialization for 'hashType.hash')
  cargo:warning=oniguruma/src/regparse.c:571:1: note: 'str_end_hash' declared here
  cargo:warning=  571 | str_end_hash(st_str_end_key* x)
  cargo:warning=      | ^~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'onig_st_init_callout_name_table_with_size':
  cargo:warning=oniguruma/src/regparse.c:678:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_callout_name_key *, st_callout_name_key *)' [-Wincompatible-pointer-types]
  cargo:warning=  678 |     callout_name_table_cmp,
  cargo:warning=      |     ^~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:678:5: note: (near initialization for 'hashType.compare')
  cargo:warning=oniguruma/src/regparse.c:637:1: note: 'callout_name_table_cmp' declared here
  cargo:warning=  637 | callout_name_table_cmp(st_callout_name_key* x, st_callout_name_key* y)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:679:5: error: initialization of 'int (*)(void)' from incompatible pointer type 'int (*)(st_callout_name_key *)' [-Wincompatible-pointer-types]
  cargo:warning=  679 |     callout_name_table_hash,
  cargo:warning=      |     ^~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c:679:5: note: (near initialization for 'hashType.hash')
  cargo:warning=oniguruma/src/regparse.c:660:1: note: 'callout_name_table_hash' declared here
  cargo:warning=  660 | callout_name_table_hash(st_callout_name_key* x)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'names_clear':
  cargo:warning=oniguruma/src/regparse.c:804:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning=  804 |     onig_st_foreach(t, i_free_name_entry, 0);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, NameEntry *, void *) {aka int (*)(unsigned char *, NameEntry *, void *)}
  cargo:warning=In file included from oniguruma/src/regparse.c:37:
  cargo:warning=oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, NameEntry *, void *)' {aka 'int (*)(unsigned char *, NameEntry *, void *)'}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro '_'
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:789:1: note: 'i_free_name_entry' declared here
  cargo:warning=  789 | i_free_name_entry(UChar* key, NameEntry* e, void* arg ARG_UNUSED)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'onig_foreach_name':
  cargo:warning=oniguruma/src/regparse.c:873:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning=  873 |     onig_st_foreach(t, i_names, (HashDataType )&narg);
  cargo:warning=      |                        ^~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, NameEntry *, INamesArg *) {aka int (*)(unsigned char *, NameEntry *, INamesArg *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, NameEntry *, INamesArg *)' {aka 'int (*)(unsigned char *, NameEntry *, INamesArg *)'}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro '_'
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:846:1: note: 'i_names' declared here
  cargo:warning=  846 | i_names(UChar* key ARG_UNUSED, NameEntry* e, INamesArg* arg)
  cargo:warning=      | ^~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'onig_renumber_name_table':
  cargo:warning=oniguruma/src/regparse.c:901:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning=  901 |     onig_st_foreach(t, i_renumber_name, (HashDataType )map);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, NameEntry *, GroupNumMap *) {aka int (*)(unsigned char *, NameEntry *, GroupNumMap *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, NameEntry *, GroupNumMap *)' {aka 'int (*)(unsigned char *, NameEntry *, GroupNumMap *)'}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro '_'
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:879:1: note: 'i_renumber_name' declared here
  cargo:warning=  879 | i_renumber_name(UChar* key ARG_UNUSED, NameEntry* e, GroupNumMap* map)
  cargo:warning=      | ^~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'callout_name_table_clear':
  cargo:warning=oniguruma/src/regparse.c:1386:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 1386 |     onig_st_foreach(t, i_free_callout_name_entry, 0);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(st_callout_name_key *, CalloutNameEntry *, void *)
  cargo:warning=oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(st_callout_name_key *, CalloutNameEntry *, void *)'
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro '_'
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:1370:1: note: 'i_free_callout_name_entry' declared here
  cargo:warning= 1370 | i_free_callout_name_entry(st_callout_name_key* key, CalloutNameEntry* e,
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'setup_ext_callout_list_values':
  cargo:warning=oniguruma/src/regparse.c:1884:56: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 1884 |     onig_st_foreach((CalloutTagTable *)ext->tag_table, i_callout_callout_list_set,
  cargo:warning=      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=      |                                                        |
  cargo:warning=      |                                                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, CalloutTagVal,  void *)' {aka 'int (*)(unsigned char *, long int,  void *)'}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro '_'
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:1866:1: note: 'i_callout_callout_list_set' declared here
  cargo:warning= 1866 | i_callout_callout_list_set(UChar* key, CalloutTagVal e, void* arg)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/regparse.c: In function 'callout_tag_table_clear':
  cargo:warning=oniguruma/src/regparse.c:1932:24: error: passing argument 2 of 'onig_st_foreach' from incompatible pointer type [-Wincompatible-pointer-types]
  cargo:warning= 1932 |     onig_st_foreach(t, i_free_callout_tag_entry, 0);
  cargo:warning=      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=      |                        |
  cargo:warning=      |                        int (*)(OnigUChar *, CalloutTagVal,  void *) {aka int (*)(unsigned char *, long int,  void *)}
  cargo:warning=oniguruma/src/st.h:55:31: note: expected 'int (*)(void)' but argument is of type 'int (*)(OnigUChar *, CalloutTagVal,  void *)' {aka 'int (*)(unsigned char *, long int,  void *)'}
  cargo:warning=   55 | int st_foreach _((st_table *, int (*)(ANYARGS), st_data_t));
  cargo:warning=      |                               ^~~~~~~~~~~~~~~~
  cargo:warning=oniguruma/src/st.h:35:18: note: in definition of macro '_'
  cargo:warning=   35 | # define _(args) args
  cargo:warning=      |                  ^~~~
  cargo:warning=oniguruma/src/regparse.c:1922:1: note: 'i_free_callout_tag_entry' declared here
  cargo:warning= 1922 | i_free_callout_tag_entry(UChar* key, CalloutTagVal e, void* arg ARG_UNUSED)
  cargo:warning=      | ^~~~~~~~~~~~~~~~~~~~~~~~

  --- stderr


  error occurred in cc-rs: command did not execute successfully (status code exit status: 1): LC_ALL="C" "/nix/store/kbw2j1vag664b3sj3rjwz9v53cqx87sb-gcc-wrapper-15.2.0/bin/cc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-I" "/build/source/target/x86_64-unknown-linux-gnu/release/build/onig_sys-34fd91aa366dab34/out" "-I" "oniguruma/src" "-fno-omit-frame-pointer" "-DHAVE_UNISTD_H=1" "-DHAVE_SYS_TYPES_H=1" "-DHAVE_SYS_TIME_H=1" "-o" "/build/source/target/x86_64-unknown-linux-gnu/release/build/onig_sys-34fd91aa366dab34/out/a445302c6d3dcb51-regparse.o" "-c" "oniguruma/src/regparse.c"


[1m[33mwarning[0m: build failed, waiting for other jobs to finish...
```

</p>
</details> 